### PR TITLE
Ignore case in Player.FindByName

### DIFF
--- a/Fougerite/Fougerite/Player.cs
+++ b/Fougerite/Fougerite/Player.cs
@@ -89,7 +89,7 @@ namespace Fougerite
             Contract.Requires(!string.IsNullOrEmpty(name));
 
             foreach (Fougerite.Player player in Fougerite.Server.GetServer().Players)
-                if (player != null && player.Name == name)
+                if (player != null && player.Name.ToLower() == name.ToLower())
                     return player;
             return null;
         }


### PR DESCRIPTION
So ingame commands like whispering or inviting someone don't require exact case name.
